### PR TITLE
Progname from cl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: required
+
 python:
   - 2.7
 
@@ -8,11 +10,7 @@ env:
     - secure: ZfUM5EuWFnPXgyw7M/dz4deW8qmxGsrCZTSeeLUeJj6lQ/zhM9Dn259IL4SuA3Neji6WOLqm6Z7SmXjm7ieFmn2/Fshuz1KWsGe8XdHDm8PUsfj1XVOpZBKqyPLUv2CPxR+V22fDaAUX3UlWdaFhsWYJzVo3GYX2fJtshFjKDJw=
     - APT_DEPENDS="gfortran-4.9 binutils"
     - PIP_DEPENDS="FoBiS.py markdown-checklist ford"
-  matrix:
     - SCRIPT="FoBiS.py rule -ex makecoverage"
-      ACTION="COVERAGE"
-    - SCRIPT="./makedoc.sh FLAP"
-      ACTION="MAKEDOC"
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -30,4 +28,5 @@ script:
 
 after_success:
   - cd $TRAVIS_BUILD_DIR
-  - if [[ $ACTION == COVERAGE ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - bash <(curl -s https://codecov.io/bash)
+  - ./makedoc.sh FLAP

--- a/makedoc.sh
+++ b/makedoc.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 GITREPO=$1
-git config --global user.name "Stefano Zaghi"
-git config --global user.email "stefano.zaghi@gmail.com"
-git clone --branch=gh-pages https://${GH_TOKEN}@github.com/szaghi/$GITREPO doc/html
 FoBiS.py rule -ex makedoc
-cd doc/html
-git add -f --all *
-git commit -m "Travis CI autocommit from travis build ${TRAVIS_BUILD_NUMBER}"
-git push -f origin gh-pages
+if [[ "${TRAVIS}" = "true" && "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
+    # Running under travis during a PR. No access to GH_TOKEN so abort
+    # documentation deployment, without throwing an error
+    exit 0
+else
+    # either we are not on TRAVIS and maybe you want to manually dpeloy documentation
+    # or we are on TRAVIS but not testing a PR so it is safe to deploy documentation
+    git config --global user.name "Stefano Zaghi"
+    git config --global user.email "stefano.zaghi@gmail.com"
+    git clone --branch=gh-pages https://${GH_TOKEN}@github.com/szaghi/$GITREPO doc/html
+    cd doc/html
+    git add -f --all *
+    git commit -m "Travis CI autocommit from travis build ${TRAVIS_BUILD_NUMBER}"
+    git push -f origin gh-pages
+fi

--- a/src/Data_Type_Command_Line_Interface.F90
+++ b/src/Data_Type_Command_Line_Interface.F90
@@ -1485,7 +1485,7 @@ contains
   !---------------------------------------------------------------------------------------------------------------------------------
   endsubroutine finalize
 
-  pure subroutine init(cli,progname,version,help,description,license,authors,examples,epilog,disable_hv)
+  subroutine init(cli,progname,version,help,description,license,authors,examples,epilog,disable_hv)
   !---------------------------------------------------------------------------------------------------------------------------------
   !< Procedure for initializing CLI.
   !---------------------------------------------------------------------------------------------------------------------------------
@@ -1500,11 +1500,26 @@ contains
   character(*), optional,             intent(IN)::    examples(1:) !< Examples of correct usage.
   character(*), optional,             intent(IN)::    epilog       !< Epilog message.
   logical,      optional,             intent(IN)::    disable_hv   !< Disable automatic inserting of 'help' and 'version' CLAs.
+
+  character(len=:) ,allocatable                 ::    prog_invocation
+  integer                                       ::    invocation_length, retrieval_status
   !---------------------------------------------------------------------------------------------------------------------------------
 
   !---------------------------------------------------------------------------------------------------------------------------------
   call cli%free
-  cli%progname    = 'program' ; if (present(progname   )) cli%progname    = progname
+  if(present(progname)) then
+     cli%progname    = progname
+  else
+     ! try to set the default progname to the 0th command line entry a-la unix $0
+     call get_command_argument(0,length=invocation_length)
+     allocate(character(len=invocation_length) :: prog_invocation)
+     call get_command_argument(0,value=prog_invocation,status=retrieval_status)
+     if (retrieval_status == 0) then
+        cli%progname = prog_invocation
+     else
+        cli%progname    = 'program'
+     end if
+  end if
   cli%version     = 'unknown' ; if (present(version    )) cli%version     = version
   cli%help        = 'usage: ' ; if (present(help       )) cli%help        = help
   cli%description = ''        ; if (present(description)) cli%description = description

--- a/src/Data_Type_Command_Line_Interface.F90
+++ b/src/Data_Type_Command_Line_Interface.F90
@@ -1526,7 +1526,7 @@ contains
   cli%license     = ''        ; if (present(license    )) cli%license     = license
   cli%authors     = ''        ; if (present(authors    )) cli%authors     = authors
   cli%epilog      = ''        ; if (present(epilog     )) cli%epilog      = epilog
-  if (present(disable_hv)) cli%disable_hv = .true.
+  if (present(disable_hv)) cli%disable_hv = disable_hv
   if (present(examples)) then
 #ifdef __GFORTRAN__
     allocate(cli%examples(1:size(examples)))


### PR DESCRIPTION
Changed the default program name to be whatever the user invoked it as.  I would like to change this to strip off the leading directories, and this may only work on unix-like systems… I don’t know if you’re OK with that or not.

For example, if I build a program without passing the `-o` flag to gfortran and then run it like `./a.out`, `progname` will default to `./a.out`. I think this is a good change since it will be a better guess of what the program name is even if it’s not explicitly set in the source code, AND, strange things won’t happen like setting the program name to ‘foo’ in the source but then compiling it named as ‘baz’. Ideally I would like the default to remove any path specification as well… `a.out` instead of `./a.out` etc. but I don’t have time to do this now, and am not sure how to treat windows…

Also fixed a small issue with optional disable_hv argument. As it was it’s presence would cause the behavior to be set as `disable_hv=.true.` even if the user passed `disable_hv=.false.`