### PR TITLE
Fix deploy.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 
 env:
   global:
-    - secure: ZfUM5EuWFnPXgyw7M/dz4deW8qmxGsrCZTSeeLUeJj6lQ/zhM9Dn259IL4SuA3Neji6WOLqm6Z7SmXjm7ieFmn2/Fshuz1KWsGe8XdHDm8PUsfj1XVOpZBKqyPLUv2CPxR+V22fDaAUX3UlWdaFhsWYJzVo3GYX2fJtshFjKDJw=
     - APT_DEPENDS="gfortran-4.9 binutils"
     - PIP_DEPENDS="FoBiS.py markdown-checklist ford"
     - SCRIPT="FoBiS.py rule -ex makecoverage"

--- a/makedoc.sh
+++ b/makedoc.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
+set -ev # echo what we're doing and fail on errors
 GITREPO=$1
-FoBiS.py rule -ex makedoc
+git config --global user.name "Stefano Zaghi"
+git config --global user.email "stefano.zaghi@gmail.com"
 if [[ "${TRAVIS}" = "true" && "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
     # Running under travis during a PR. No access to GH_TOKEN so abort
     # documentation deployment, without throwing an error
+    FoBiS.py rule -ex makedoc
     exit 0
-else
-    # either we are not on TRAVIS and maybe you want to manually dpeloy documentation
-    # or we are on TRAVIS but not testing a PR so it is safe to deploy documentation
-    git config --global user.name "Stefano Zaghi"
-    git config --global user.email "stefano.zaghi@gmail.com"
-    git clone --branch=gh-pages https://${GH_TOKEN}@github.com/szaghi/$GITREPO doc/html
-    cd doc/html
-    git add -f --all *
-    git commit -m "Travis CI autocommit from travis build ${TRAVIS_BUILD_NUMBER}"
-    git push -f origin gh-pages
 fi
+# either we are not on TRAVIS and maybe you want to manually dpeloy documentation
+# or we are on TRAVIS but not testing a PR so it is safe to deploy documentation
+git clone --branch=gh-pages https://${GH_TOKEN}@github.com/szaghi/$GITREPO doc/html
+FoBiS.py rule -ex makedoc
+cd doc/html
+git add -f --all './*'
+git commit -m "Travis CI autocommit from travis build ${TRAVIS_BUILD_NUMBER}"
+git push -f origin gh-pages


### PR DESCRIPTION
**IMPORTANT:** I have removed the encrypted GH_TOKEN variable from the .travis.yml, so that it can be added directly on Travis-CI through the repository settings web interface. I **think** that using the web interface does a better job of making sure that variable contents don’t leak into the logs. Generate your new GH token then head over to: https://travis-ci.org/profile/szaghi and then click the gear ‘settings’ icon next to szaghi/FLAP. Then click on the ‘environment variables’ tab and ‘add new variable’.  Then enter GH_TOKEN for the name and the corresponding newly generated token as the value. Make sure that the ‘display value in build logs’ setting is set to ‘off’. *Please do this before attempting to merge this PR so we can see if the documentation deploys correctly and whether or not the token is exposed.*

- documentation deployment *should* work now
 - exposed token should be resolved
 - better informational printing and error notifications
 - .travis.yml updated under the assumption that @szaghi moved to web interface for encrypted variables
 - removed empty .gitignore added when demonstrating security breach