### PR TITLE
Some minor fixes after to compile with IBM XL Fortran for Linux, V14.1

### DIFF
--- a/src/Data_Type_Command_Line_Interface.F90
+++ b/src/Data_Type_Command_Line_Interface.F90
@@ -2219,6 +2219,7 @@ contains
   character(len=:), allocatable                        :: descriptiond      !< Detailed description.
   character(len=:), allocatable                        :: excluded          !< Group name of the mutually exclusive group.
   integer(I4P)                                         :: Ng                !< Number of groups.
+  integer(I4P)                                         :: gi                !< Group index
   !---------------------------------------------------------------------------------------------------------------------------------
 
   !---------------------------------------------------------------------------------------------------------------------------------
@@ -2228,7 +2229,10 @@ contains
     excluded     = ''        ; if (present(exclude    )) excluded     = exclude
     Ng = size(cli%clasg,dim=1)
     allocate(clasg_list_new(0:Ng))
-    clasg_list_new(0:Ng-1) = cli%clasg(0:Ng-1)
+!    clasg_list_new(0:Ng-1) = cli%clasg(0:Ng-1) ! Not working on Intel Fortran 15.0.2
+    do gi = 0, Ng-1     
+      clasg_list_new(gi) = cli%clasg(gi)
+    enddo
     call clasg_list_new(Ng)%assign_object(cli)
     clasg_list_new(Ng)%help        = helpd
     clasg_list_new(Ng)%description = descriptiond

--- a/src/Data_Type_Command_Line_Interface.F90
+++ b/src/Data_Type_Command_Line_Interface.F90
@@ -225,7 +225,9 @@ integer(I4P), parameter :: status_clasg_print_h             = -2 !< Print help s
 !-----------------------------------------------------------------------------------------------------------------------------------
 contains
   ! auxiliary procedures
-  elemental function Upper_Case(string)
+  function Upper_Case(string)
+  ! elemental function Upper_Case(string)
+  ! 1513-209 (S) The result of an elemental function must be a nonpointer, nonallocatable scalar, and its type parameters must be constant expressions.
   !---------------------------------------------------------------------------------------------------------------------------------
   !< Convert the lower case characters of a string to upper case one.
   !---------------------------------------------------------------------------------------------------------------------------------

--- a/src/Data_Type_Command_Line_Interface.F90
+++ b/src/Data_Type_Command_Line_Interface.F90
@@ -2315,6 +2315,7 @@ contains
   cla%hidden     = .false.                 ; if (present(hidden    )) cla%hidden     = hidden
   cla%act        = action_store            ; if (present(act       )) cla%act        = trim(adjustl(Upper_Case(act)))
                                              if (present(def       )) cla%def        = def
+                                             if (present(def       )) cla%val        = def
                                              if (present(nargs     )) cla%nargs      = nargs
                                              if (present(choices   )) cla%choices    = choices
   cla%m_exclude  = ''                      ; if (present(exclude   )) cla%m_exclude  = exclude


### PR DESCRIPTION
    Deleted "elemental" in fuction Upper_Case due to the following XLF
    following compiler error:

    "1513-209 (S) The result of an elemental function must be a
     nonpointer, nonallocatable scalar, and its type parameters must
     be constant expressions."

After changing this line it compiles with XLF v14.1.

This behaviour also occurs in Lib_VTK_IO:

https://github.com/victorsndvg/Lib_VTK_IO/commit/226c38e3e52051371e540b5fde66bcde16f5648f#diff-6952d71b75ad07086220a941f2a61ba7L538