### PR TITLE
fix for FPM dependency

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/szaghi/FLAP"
 
 [dependencies]
 FACE = { git="https://github.com/szaghi/FACE.git", rev="5102983a77ab76dc563ef36ebaf8a6839c0bfe6d" }
-PENF = { git="https://github.com/jacobwilliams/PENF.git", branch="fpm-support" }
+PENF = { git="https://github.com/szaghi/PENF.git", rev="a519e6cb58873efa85a81b4cf0a547870f510629" }
 
 [library]
 source-dir = "src/lib"


### PR DESCRIPTION
Minor cleanup.

In `fpm.toml`, points the `PENF` dependency to latest https://github.com/szaghi/PENF.git rather than my fork.