### PR TITLE
Addition of a default flag --markdown

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -7,7 +7,7 @@ maintainer = "Stefano Zaghi"
 homepage = "https://github.com/szaghi/FLAP"
 
 [dependencies]
-FACE = { git="https://github.com/szaghi/FACE.git", rev="5102983a77ab76dc563ef36ebaf8a6839c0bfe6d" }
+FACE = { git="https://github.com/szaghi/FACE.git", rev="1455c549ae0c1ead96961ca61a73131d8176b6a4" }
 PENF = { git="https://github.com/szaghi/PENF.git", rev="a519e6cb58873efa85a81b4cf0a547870f510629" }
 
 [library]

--- a/src/lib/flap_command_line_argument_t.F90
+++ b/src/lib/flap_command_line_argument_t.F90
@@ -319,7 +319,11 @@ contains
           endif
         endif
       else
-        usage = '  value'
+        if (markdownd) then
+          usage = new_line('a')//'* value'
+        else
+          usage = '  value'
+        endif
       endif
       if (allocated(self%choices)) then
         usage = usage//', value in: `'//self%choices//'`'

--- a/src/lib/flap_command_line_argument_t.F90
+++ b/src/lib/flap_command_line_argument_t.F90
@@ -292,13 +292,13 @@ contains
           endselect
           if (trim(adjustl(self%switch))/=trim(adjustl(self%switch_ab))) then
             if (markdownd) then
-              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//usage//'`, `'//trim(adjustl(self%switch_ab))//usage//'`'
+              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//usage//'`, `'//trim(adjustl(self%switch_ab))//usage//'`  '
             else
               usage = '   '//switch_//usage//', '//switch_ab_//usage
             endif
           else
             if (markdownd) then
-              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//usage//'`'
+              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//usage//'`  '
             else
               usage = '   '//switch_//usage
             endif
@@ -306,13 +306,13 @@ contains
         else
           if (trim(adjustl(self%switch))/=trim(adjustl(self%switch_ab))) then
             if (markdownd) then
-              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//' value`, `'//trim(adjustl(self%switch_ab))//' value'//'`'
+              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//' value`, `'//trim(adjustl(self%switch_ab))//' value'//'`  '
             else
               usage = '   '//switch_//' value, '//switch_ab_//' value'
             endif
           else
             if (markdownd) then
-              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//' value`'
+              usage = new_line('a')//'* `'//trim(adjustl(self%switch))//' value`  '
             else
               usage = '   '//switch_//' value'
             endif
@@ -332,13 +332,13 @@ contains
     else
       if (trim(adjustl(self%switch))/=trim(adjustl(self%switch_ab))) then
         if (markdownd) then
-          usage = new_line('a')//'* `'//trim(adjustl(self%switch))//'`, `'//trim(adjustl(self%switch_ab))//'`'
+          usage = new_line('a')//'* `'//trim(adjustl(self%switch))//'`, `'//trim(adjustl(self%switch_ab))//'`  '
         else
           usage = '   '//switch_//', '//switch_ab_
         endif
       else
         if (markdownd) then
-          usage = new_line('a')//'* `'//trim(adjustl(self%switch))//'`'
+          usage = new_line('a')//'* `'//trim(adjustl(self%switch))//'`  '
         else
           usage = '   '//switch_
         endif
@@ -346,8 +346,14 @@ contains
     endif
     prefd = '' ; if (present(pref)) prefd = pref
     usage = prefd//usage
-    if (self%is_positional) usage = usage//new_line('a')//prefd//repeat(' ',indent)//trim(str(self%position, .true.))//&
-      '-th argument'
+    if (self%is_positional)then
+      ! two spaces make a line break in markdown.
+      if (markdownd) then
+        usage = usage//'  '
+      endif
+      usage = usage//new_line('a')//prefd//repeat(' ',4)//trim(str(self%position, .true.))//&
+       '-th argument'
+    endif
     if (allocated(self%envvar)) then
       if (self%envvar /= '') then
         usage = usage//new_line('a')//prefd//repeat(' ',10)//'environment variable name "'//trim(adjustl(self%envvar))//'"'
@@ -365,9 +371,9 @@ contains
     endif
     if (self%m_exclude/='') usage = usage//new_line('a')//prefd//repeat(' ', indent)//'mutually exclude "'//self%m_exclude//'"'
     if (markdownd) then
-      usage = usage//'  '//new_line('a')//prefd//repeat(' ',4)//trim(adjustl(self%help))
+      usage = usage//'  '//new_line('a')//prefd//repeat(' ',4)//trim(adjustl(self%help))//'  '
       if (self%help_markdown/='') then
-        usage = usage//trim(adjustl(self%help_markdown))
+        usage = usage//trim(adjustl(self%help_markdown))//'  '
       endif
     else
       usage = usage//new_line('a')//prefd//repeat(' ', indent)//trim(adjustl(self%help))

--- a/src/lib/flap_command_line_argument_t.F90
+++ b/src/lib/flap_command_line_argument_t.F90
@@ -16,6 +16,7 @@ public :: ACTION_STORE_STAR
 public :: ACTION_STORE_TRUE
 public :: ACTION_STORE_FALSE
 public :: ACTION_PRINT_HELP
+public :: ACTION_PRINT_MARK
 public :: ACTION_PRINT_VERS
 public :: ARGS_SEP
 public :: ERROR_UNKNOWN
@@ -102,6 +103,7 @@ character(len=*), parameter :: ACTION_STORE_STAR  = 'STORE*'        !< Store val
 character(len=*), parameter :: ACTION_STORE_TRUE  = 'STORE_TRUE'    !< Store .true. without the necessity of a value.
 character(len=*), parameter :: ACTION_STORE_FALSE = 'STORE_FALSE'   !< Store .false. without the necessity of a value.
 character(len=*), parameter :: ACTION_PRINT_HELP  = 'PRINT_HELP'    !< Print help message.
+character(len=*), parameter :: ACTION_PRINT_MARK  = 'PRINT_MARKDOWN'!< Print help to Markdown file.
 character(len=*), parameter :: ACTION_PRINT_VERS  = 'PRINT_VERSION' !< Print version.
 character(len=*), parameter :: ARGS_SEP           = '||!||'         !< Arguments separator for multiple valued (list) CLA.
 
@@ -657,6 +659,7 @@ contains
         self%act/=ACTION_STORE_TRUE.and. &
         self%act/=ACTION_STORE_FALSE.and.&
         self%act/=ACTION_PRINT_HELP.and. &
+        self%act/=ACTION_PRINT_MARK.and. &
         self%act/=ACTION_PRINT_VERS) then
       call self%errored(pref=pref, error=ERROR_ACTION_UNKNOWN)
       return

--- a/src/lib/flap_command_line_arguments_group_t.f90
+++ b/src/lib/flap_command_line_arguments_group_t.f90
@@ -473,6 +473,7 @@ contains
   endif
   if (self%Na_required>0) then
     usage = usage//new_line('a')//new_line('a')//prefd//'Required switches:'
+    if(markdownd)usage = usage//'  '
     do a=1, self%Na
       if (self%cla(a)%is_required.and.(.not.self%cla(a)%is_hidden)) usage = usage//new_line('a')//&
         self%cla(a)%usage(pref=prefd,markdown=markdownd)
@@ -480,6 +481,7 @@ contains
   endif
   if (self%Na_optional>0) then
     usage = usage//new_line('a')//new_line('a')//prefd//'Optional switches:'
+    if(markdownd)usage = usage//'  '
     do a=1, self%Na
       if (.not.self%cla(a)%is_required.and.(.not.self%cla(a)%is_hidden)) usage = usage//new_line('a')//&
         self%cla(a)%usage(pref=prefd,markdown=markdownd)

--- a/src/lib/flap_command_line_arguments_group_t.f90
+++ b/src/lib/flap_command_line_arguments_group_t.f90
@@ -5,6 +5,7 @@ module flap_command_line_arguments_group_t
 use face, only : colorize
 use flap_command_line_argument_t, only : command_line_argument, &
                                          ACTION_PRINT_HELP,     &
+                                         ACTION_PRINT_MARK,     &
                                          ACTION_PRINT_VERS,     &
                                          ACTION_STORE,          &
                                          ACTION_STORE_STAR,     &
@@ -18,6 +19,7 @@ save
 public :: command_line_arguments_group
 public :: STATUS_PRINT_V
 public :: STATUS_PRINT_H
+public :: STATUS_PRINT_M
 
 type, extends(object) :: command_line_arguments_group
   !< Command Line Arguments Group (CLAsG) class.
@@ -54,6 +56,7 @@ endtype command_line_arguments_group
 ! status codes
 integer(I4P), parameter :: STATUS_PRINT_V = -1 !< Print version status.
 integer(I4P), parameter :: STATUS_PRINT_H = -2 !< Print help status.
+integer(I4P), parameter :: STATUS_PRINT_M = -3 !< Print help status to Markdown file.
 
 ! errors codes
 integer(I4P), parameter :: ERROR_CONSISTENCY = 100 !< CLAs group consistency error.
@@ -393,6 +396,8 @@ contains
                     endif
                  elseif (self%cla(a)%act==action_print_help) then
                     self%error = STATUS_PRINT_H
+                 elseif (self%cla(a)%act==action_print_mark) then
+                    self%error = STATUS_PRINT_M
                  elseif (self%cla(a)%act==action_print_vers) then
                     self%error = STATUS_PRINT_V
                  endif

--- a/src/lib/flap_command_line_interface_t.F90
+++ b/src/lib/flap_command_line_interface_t.F90
@@ -4,7 +4,7 @@ module flap_command_line_interface_t
 
 use face, only : colorize
 use flap_command_line_argument_t, only : command_line_argument, ACTION_STORE, ERROR_UNKNOWN
-use flap_command_line_arguments_group_t, only : command_line_arguments_group, STATUS_PRINT_H, STATUS_PRINT_V
+use flap_command_line_arguments_group_t, only : command_line_arguments_group, STATUS_PRINT_H, STATUS_PRINT_M, STATUS_PRINT_V
 use flap_object_t, only : object
 use flap_utils_m
 use penf
@@ -453,7 +453,7 @@ contains
   if (present(error)) error = 0
   if (self%is_parsed_) return
 
-  ! add help and version switches if not done by user
+  ! add help, markdown and version switches if not done by user
   if (.not.self%disable_hv) then
     do g=0,size(self%clasg,dim=1)-1
       if (.not.(self%is_defined(group=self%clasg(g)%group, switch='--help').and.&
@@ -466,6 +466,16 @@ contains
                       required    = .false.,                   &
                       def         = '',                        &
                       act         = 'print_help')
+      if (.not.(self%is_defined(group=self%clasg(g)%group, switch='--markdown').and.&
+                self%is_defined(group=self%clasg(g)%group, switch='-md'))) &
+        call self%add(pref        = pref,                      &
+                      group_index = g,                         &
+                      switch      = '--markdown',              &
+                      switch_ab   = '-md',                     &
+                      help        = 'Save this help message in a Markdown file', &
+                      required    = .false.,                   &
+                      def         = '',                        &
+                      act         = 'print_markdown')
       if (.not.(self%is_defined(group=self%clasg(g)%group, switch='--version').and. &
                 self%is_defined(group=self%clasg(g)%group, switch='-v'))) &
         call self%add(pref        = pref,            &
@@ -549,6 +559,9 @@ contains
         stop
       endif
     enddo
+  elseif (self%error == STATUS_PRINT_M) then
+    call self%save_usage_to_markdown(trim(self%progname)//'.md')
+    stop
   endif
 
   ! check if all required CLAs have been passed


### PR DESCRIPTION
I propose to add a default built-in flag `--markdown` to save the help message in a Markdown file.